### PR TITLE
Fix UnixSyslog message ident corruption, closes graylog-labs/syslog4j…

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/impl/unix/UnixSyslog.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/unix/UnixSyslog.java
@@ -37,6 +37,8 @@ public class UnixSyslog extends AbstractSyslog {
         public void closelog();
     }
 
+    protected static Memory identBuffer = null;
+
     protected static int currentFacility = -1;
     protected static boolean openlogCalled = false;
 
@@ -80,8 +82,6 @@ public class UnixSyslog extends AbstractSyslog {
                 if (ident != null && "".equals(ident.trim())) {
                     ident = null;
                 }
-
-                Memory identBuffer = null;
 
                 if (ident != null) {
                     identBuffer = new Memory(128);


### PR DESCRIPTION
…-graylog2#20

According to libc openlog function documentation "if the string *ident
points to ceases to exist, the results are undefined". So we have to
keep the identBuffer during the existence of the Syslog object.