### PR TITLE
Fix for FACILITY transfer

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
+++ b/src/main/java/org/graylog2/syslog4j/SyslogConstants.java
@@ -77,35 +77,35 @@ public interface SyslogConstants extends Serializable {
     public static final byte TCP_MAX_ACTIVE_SOCKETS_BEHAVIOR_DEFAULT = 0;
 
     public static final int FACILITY_KERN = 0;
-    public static final int FACILITY_USER = 1 << 3;
-    public static final int FACILITY_MAIL = 2 << 3;
-    public static final int FACILITY_DAEMON = 3 << 3;
-    public static final int FACILITY_AUTH = 4 << 3;
-    public static final int FACILITY_SYSLOG = 5 << 3;
+    public static final int FACILITY_USER = 1;
+    public static final int FACILITY_MAIL = 2;
+    public static final int FACILITY_DAEMON = 3;
+    public static final int FACILITY_AUTH = 4;
+    public static final int FACILITY_SYSLOG = 5;
 
-    public static final int FACILITY_LPR = 6 << 3;
-    public static final int FACILITY_NEWS = 7 << 3;
-    public static final int FACILITY_UUCP = 8 << 3;
-    public static final int FACILITY_CRON = 9 << 3;
-    public static final int FACILITY_AUTHPRIV = 10 << 3;
-    public static final int FACILITY_FTP = 11 << 3;
+    public static final int FACILITY_LPR = 6;
+    public static final int FACILITY_NEWS = 7;
+    public static final int FACILITY_UUCP = 8;
+    public static final int FACILITY_CRON = 9;
+    public static final int FACILITY_AUTHPRIV = 10;
+    public static final int FACILITY_FTP = 11;
 
     // add constants according to
     // The BSD syslog Protocol, 4.1.1 PRI Part
     // https://www.ietf.org/rfc/rfc3164.txt
-    public static final int FACILITY_NTP = 12 << 3;
-    public static final int FACILITY_AUDIT = 13 << 3;
-    public static final int FACILITY_ALERT = 14 << 3;
-    public static final int FACILITY_CLOCK2 = 15 << 3;
+    public static final int FACILITY_NTP = 12;
+    public static final int FACILITY_AUDIT = 13;
+    public static final int FACILITY_ALERT = 14;
+    public static final int FACILITY_CLOCK2 = 15;
 
-    public static final int FACILITY_LOCAL0 = 16 << 3;
-    public static final int FACILITY_LOCAL1 = 17 << 3;
-    public static final int FACILITY_LOCAL2 = 18 << 3;
-    public static final int FACILITY_LOCAL3 = 19 << 3;
-    public static final int FACILITY_LOCAL4 = 20 << 3;
-    public static final int FACILITY_LOCAL5 = 21 << 3;
-    public static final int FACILITY_LOCAL6 = 22 << 3;
-    public static final int FACILITY_LOCAL7 = 23 << 3;
+    public static final int FACILITY_LOCAL0 = 16;
+    public static final int FACILITY_LOCAL1 = 17;
+    public static final int FACILITY_LOCAL2 = 18;
+    public static final int FACILITY_LOCAL3 = 19;
+    public static final int FACILITY_LOCAL4 = 20;
+    public static final int FACILITY_LOCAL5 = 21;
+    public static final int FACILITY_LOCAL6 = 22;
+    public static final int FACILITY_LOCAL7 = 23;
 
     public static final int SYSLOG_FACILITY_DEFAULT = FACILITY_USER;
 

--- a/src/main/java/org/graylog2/syslog4j/impl/message/processor/AbstractSyslogMessageProcessor.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/message/processor/AbstractSyslogMessageProcessor.java
@@ -65,7 +65,7 @@ public abstract class AbstractSyslogMessageProcessor implements SyslogMessagePro
     }
 
     protected void appendPriority(StringBuffer buffer, int facility, int level) {
-        int priority = facility | level;
+        int priority = (facility << 3 ) | level;
 
         buffer.append("<");
         buffer.append(priority);

--- a/src/main/java/org/graylog2/syslog4j/impl/unix/UnixSyslog.java
+++ b/src/main/java/org/graylog2/syslog4j/impl/unix/UnixSyslog.java
@@ -92,7 +92,7 @@ public class UnixSyslog extends AbstractSyslog {
                 openlogCalled = true;
             }
 
-            int priority = currentFacility | level;
+            int priority = (currentFacility << 3) | level;
 
             libraryInstance.syslog(priority, "%s", message);
         }

--- a/src/test/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEventTest.java
+++ b/src/test/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEventTest.java
@@ -1,5 +1,7 @@
 package org.graylog2.syslog4j.server.impl.event;
 
+import org.graylog2.syslog4j.SyslogConstants;
+import org.graylog2.syslog4j.util.SyslogUtility;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -223,5 +225,20 @@ public class SyslogServerEventTest {
         assertEquals("hostname", event5.getHost());
         assertEquals(0, event5.getLevel());
         assertEquals("hostname test[42]: Test", event5.getMessage());
+    }
+
+    @Test
+    public void testFacilityConversion() throws Exception {
+        // as per RFC-5424
+        assertEquals(20, SyslogConstants.FACILITY_LOCAL4);
+        assertEquals(6, SyslogConstants.LEVEL_INFO);
+        assertEquals("local4", SyslogUtility.getFacilityString(SyslogConstants.FACILITY_LOCAL4));
+
+        // 20*8 + 6 = 166
+        final String message = "<166>2016-10-12T14:10:18Z hostname testmsg[20]: Test";
+        final SyslogServerEvent event = buildEvent(message);
+
+        assertEquals(SyslogConstants.FACILITY_LOCAL4, event.facility);
+        assertEquals(SyslogConstants.LEVEL_INFO, event.level);
     }
 }


### PR DESCRIPTION
Fixes #35 
I came upon the problem that the server part would not report the proper facility for messages.

This patch fixes the problem by
- changing the constants in `SyslogUtiliites` to match RFC 5424 (this fixes the decoding part)
- fixing the encoding accordingly
