### PR TITLE
Syslog input configurable timzone

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEvent.java
@@ -29,7 +29,7 @@ public class CiscoSyslogServerEvent extends SyslogServerEvent {
     public CiscoSyslogServerEvent(final byte[] message, int length, InetAddress inetAddress) {
         super();
 
-        initialize(message, length, inetAddress);
+        initialize(message, length, inetAddress, null);
         parse();
     }
     public CiscoSyslogServerEvent(final byte[] message, int length, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
@@ -42,7 +42,7 @@ public class CiscoSyslogServerEvent extends SyslogServerEvent {
     public CiscoSyslogServerEvent(final String message, InetAddress inetAddress) {
         super();
 
-        initialize(message, inetAddress);
+        initialize(message, inetAddress, null);
         parse();
     }
 
@@ -171,7 +171,4 @@ public class CiscoSyslogServerEvent extends SyslogServerEvent {
         return sequenceNumber;
     }
 
-    private ZoneId getDefaultServerZoneId() {
-        return Objects.isNull(sysLogServerTimeZone) ? ZoneOffset.UTC : sysLogServerTimeZone.toTimeZone().toZoneId();
-    }
 }

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEvent.java
@@ -3,15 +3,12 @@ package org.graylog2.syslog4j.server.impl.event;
 import org.joda.time.DateTimeZone;
 
 import java.net.InetAddress;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Objects;
 
 /**
  * CiscoSyslogServerEvent provides an implementation of the

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
@@ -11,6 +11,8 @@ import java.net.InetAddress;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -61,7 +63,7 @@ public class SyslogServerEvent implements SyslogServerEventIF {
     }
 
     public SyslogServerEvent(final byte[] message, int length, InetAddress inetAddress) {
-        initialize(message, length, inetAddress);
+        initialize(message, length, inetAddress, null);
 
         parse();
     }
@@ -72,28 +74,20 @@ public class SyslogServerEvent implements SyslogServerEventIF {
         parse();
     }
 
-    protected void initialize(final String message, InetAddress inetAddress) {
+    protected void initialize(final String message, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
         this.rawString = message;
         this.rawLength = message.length();
         this.inetAddress = inetAddress;
-
         this.message = message;
-    }
-
-    protected void initialize(final String message, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
         this.sysLogServerTimeZone = sysLogServerTimeZone;
-        initialize(message, inetAddress);
     }
 
-    protected void initialize(final byte[] message, int length, InetAddress inetAddress) {
+
+    protected void initialize(final byte[] message, int length, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
         this.rawBytes = message;
         this.rawLength = length;
         this.inetAddress = inetAddress;
-    }
-
-    protected void initialize(final byte[] message, int length, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
         this.sysLogServerTimeZone = sysLogServerTimeZone;
-        initialize(message, length, inetAddress);
     }
 
     protected void parseHost() {
@@ -220,6 +214,10 @@ public class SyslogServerEvent implements SyslogServerEventIF {
 
             return newRawBytes;
         }
+    }
+
+    protected ZoneId getDefaultServerZoneId() {
+        return Objects.isNull(sysLogServerTimeZone) ? ZoneOffset.UTC : sysLogServerTimeZone.toTimeZone().toZoneId();
     }
 
     public int getRawLength() {

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
@@ -148,13 +148,16 @@ public class SyslogServerEvent implements SyslogServerEventIF {
     }
 
     private DateTime parse8601Date(String date) {
-        boolean hasTimezone = date.substring(date.length() - 6).matches(".*[Z+-].*");
 
-        if (!hasTimezone && Objects.nonNull(sysLogServerTimeZone)) {
+        if (!hasTimeZone(date) && Objects.nonNull(sysLogServerTimeZone)) {
             return DateTime.parse(date, ISODateTimeFormat.dateTimeParser().withZone(sysLogServerTimeZone));
         }
 
         return DateTime.parse(date);
+    }
+
+    protected boolean hasTimeZone(String date) {
+        return date.substring(date.length() - 6).matches(".*[Z+-].*");
     }
 
     protected void parsePriority() {

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
@@ -4,6 +4,8 @@ import org.graylog2.syslog4j.SyslogConstants;
 import org.graylog2.syslog4j.server.SyslogServerEventIF;
 import org.graylog2.syslog4j.util.SyslogUtility;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.net.InetAddress;
 import java.text.DateFormat;
@@ -12,6 +14,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * SyslogServerEvent provides an implementation of the SyslogServerEventIF interface.
@@ -40,18 +43,31 @@ public class SyslogServerEvent implements SyslogServerEventIF {
     protected boolean isHostStrippedFromMessage = false;
     protected String message = null;
     protected InetAddress inetAddress = null;
+    protected DateTimeZone sysLogServerTimeZone;
 
     protected SyslogServerEvent() {
     }
 
     public SyslogServerEvent(final String message, InetAddress inetAddress) {
-        initialize(message, inetAddress);
+        initialize(message, inetAddress, null);
+
+        parse();
+    }
+
+    public SyslogServerEvent(final String message, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
+        initialize(message, inetAddress, sysLogServerTimeZone);
 
         parse();
     }
 
     public SyslogServerEvent(final byte[] message, int length, InetAddress inetAddress) {
         initialize(message, length, inetAddress);
+
+        parse();
+    }
+
+    public SyslogServerEvent(final byte[] message, int length, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
+        initialize(message, length, inetAddress, sysLogServerTimeZone);
 
         parse();
     }
@@ -64,10 +80,20 @@ public class SyslogServerEvent implements SyslogServerEventIF {
         this.message = message;
     }
 
+    protected void initialize(final String message, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
+        this.sysLogServerTimeZone = sysLogServerTimeZone;
+        initialize(message, inetAddress);
+    }
+
     protected void initialize(final byte[] message, int length, InetAddress inetAddress) {
         this.rawBytes = message;
         this.rawLength = length;
         this.inetAddress = inetAddress;
+    }
+
+    protected void initialize(final byte[] message, int length, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
+        this.sysLogServerTimeZone = sysLogServerTimeZone;
+        initialize(message, length, inetAddress);
     }
 
     protected void parseHost() {
@@ -96,16 +122,13 @@ public class SyslogServerEvent implements SyslogServerEventIF {
                 isDate8601 = true;
             }
 
-            String year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR));
             String originalDate = this.message.substring(0, datelength - 1);
-            String modifiedDate = originalDate + " " + year;
 
-            DateFormat dateFormat = new SimpleDateFormat(dateFormatS, Locale.ENGLISH);
             try {
                 if (!isDate8601) {
-                    this.date = dateFormat.parse(modifiedDate);
+                    this.date = parseDateBasedOnFormat(originalDate, datelength, dateFormatS);
                 } else {
-                    this.date = DateTime.parse(originalDate).toDate();
+                    this.date = parse8601Date(originalDate).toDate();
                 }
 
                 this.message = this.message.substring(datelength);
@@ -116,6 +139,28 @@ public class SyslogServerEvent implements SyslogServerEventIF {
         }
 
         parseHost();
+    }
+
+    private Date parseDateBasedOnFormat(String originalDate, int dateLength, String format) throws ParseException {
+        String year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR));
+        String modifiedDate = originalDate + " " + year;
+        DateFormat dateFormat = new SimpleDateFormat(format, Locale.ENGLISH);
+
+        if (Objects.nonNull(sysLogServerTimeZone)) {
+            dateFormat.setTimeZone(sysLogServerTimeZone.toTimeZone());
+        }
+
+        return dateFormat.parse(modifiedDate);
+    }
+
+    private DateTime parse8601Date(String date) {
+        boolean hasTimezone = date.substring(date.length() - 6).matches(".*[Z+-].*");
+
+        if (!hasTimezone && Objects.nonNull(sysLogServerTimeZone)) {
+            return DateTime.parse(date, ISODateTimeFormat.dateTimeParser().withZone(sysLogServerTimeZone));
+        }
+
+        return DateTime.parse(date);
     }
 
     protected void parsePriority() {

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEvent.java
@@ -4,11 +4,13 @@ import org.graylog2.syslog4j.SyslogConstants;
 import org.graylog2.syslog4j.impl.message.structured.StructuredSyslogMessage;
 import org.graylog2.syslog4j.server.impl.event.SyslogServerEvent;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.net.InetAddress;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * SyslogServerStructuredEvent provides an implementation of the
@@ -43,10 +45,23 @@ public class StructuredSyslogServerEvent extends SyslogServerEvent {
         parse();
     }
 
+    public StructuredSyslogServerEvent(final byte[] message, int length, InetAddress inetAddres, DateTimeZone sysLogServerTimeZone) {
+        super();
+
+        initialize(message, length, inetAddress, sysLogServerTimeZone);
+        parse();
+    }
+
     public StructuredSyslogServerEvent(final String message, InetAddress inetAddress) {
         super();
 
         initialize(message, inetAddress, null);
+        parse();
+    }
+    public StructuredSyslogServerEvent(final String message, InetAddress inetAddress, DateTimeZone sysLogServerTimeZone) {
+        super();
+
+        initialize(message, inetAddress, sysLogServerTimeZone);
         parse();
     }
 
@@ -102,6 +117,10 @@ public class StructuredSyslogServerEvent extends SyslogServerEvent {
 
             try {
                 DateTimeFormatter formatter = getDateTimeFormatter();
+
+                if (!hasTimeZone(dateString) && Objects.nonNull(sysLogServerTimeZone)) {
+                    formatter = formatter.withZone(sysLogServerTimeZone);
+                }
 
                 this.dateTime = formatter.parseDateTime(dateString);
                 this.date = this.dateTime.toDate();

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEvent.java
@@ -39,14 +39,14 @@ public class StructuredSyslogServerEvent extends SyslogServerEvent {
     public StructuredSyslogServerEvent(final byte[] message, int length, InetAddress inetAddress) {
         super();
 
-        initialize(message, length, inetAddress);
+        initialize(message, length, inetAddress, null);
         parse();
     }
 
     public StructuredSyslogServerEvent(final String message, InetAddress inetAddress) {
         super();
 
-        initialize(message, inetAddress);
+        initialize(message, inetAddress, null);
         parse();
     }
 

--- a/src/test/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEventTest.java
+++ b/src/test/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEventTest.java
@@ -6,11 +6,8 @@ import org.junit.Test;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
-import java.util.Locale;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,15 +21,15 @@ public class CiscoSyslogServerEventTest {
     private static final ZoneId CET = ZoneId.of("CET");
     private static final int YEAR = ZonedDateTime.now().getYear();
 
-    private CiscoSyslogServerEvent buildEvent(String message) {
-        return new CiscoSyslogServerEvent(message, INET_ADDR);
+    private CiscoSyslogServerEvent buildEvent(String message, DateTimeZone defaultZone) {
+        return new CiscoSyslogServerEvent(message, INET_ADDR, defaultZone);
     }
 
     @Test
     public void testCisco1() throws Exception {
         final String message = "<166>Mar 06 2016 12:53:10 DEVICENAME : %ASA-6-302013: Built inbound TCP connection 723494125 for FRONTEND:IP/11288 (IP/11288) to BACKEND:IP/27180 (IP/27180)";
 
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(toZonedDateTime(event.getDate(), UTC)).isEqualTo(ZonedDateTime.of(2016, 3, 6, 12, 53, 10, 0, UTC));
         assertThat(event.getFacility()).isEqualTo(20);
@@ -46,7 +43,7 @@ public class CiscoSyslogServerEventTest {
     public void testCisco2() throws Exception {
         final String message = "<186>1541800: Feb 27 06:08:59.485: %HARDWARE-2-FAN_ERROR: Fan Failure";
 
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(toZonedDateTime(event.getDate(), UTC)).isEqualTo(ZonedDateTime.of(YEAR, 2, 27, 6, 8, 59, 485_000_000, UTC));
         assertThat(event.getFacility()).isEqualTo(23);
@@ -60,7 +57,7 @@ public class CiscoSyslogServerEventTest {
     public void testCisco3() throws Exception {
         final String message = "<187>148094: Feb 27 06:07:29.716: %LINK-3-UPDOWN: Interface GigabitEthernet1/0/15, changed state to down";
 
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(toZonedDateTime(event.getDate(), UTC)).isEqualTo(ZonedDateTime.of(YEAR, 2, 27, 6, 7, 29, 716_000_000, UTC));
         assertThat(event.getFacility()).isEqualTo(23);
@@ -74,7 +71,7 @@ public class CiscoSyslogServerEventTest {
     public void testCisco4() throws Exception {
         final String message = "<190>530470: *Sep 28 17:13:35.098: %SEC-6-IPACCESSLOGP: list MGMT_IN denied udp IP(49964) -> IP(161), 11 packets";
 
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(toZonedDateTime(event.getDate(), UTC)).isEqualTo(ZonedDateTime.of(YEAR, 9, 28, 17, 13, 35, 98_000_000, UTC));
         assertThat(event.getFacility()).isEqualTo(23);
@@ -88,7 +85,7 @@ public class CiscoSyslogServerEventTest {
     public void testCisco5() throws Exception {
         final String message = "<190>: 2016 Mar 06 09:22:34 CET: %AUTHPRIV-6-SYSTEM_MSG: START: rsync pid=4311 from=::ffff:IP - xinetd[6219]";
 
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(toZonedDateTime(event.getDate(), CET)).isEqualTo(ZonedDateTime.of(2016, 3, 6, 9, 22, 34, 0, CET));
         assertThat(event.getFacility()).isEqualTo(23);
@@ -102,7 +99,7 @@ public class CiscoSyslogServerEventTest {
     public void testCisco6() throws Exception {
         final String message = "<134>: 2016 Mar  6 12:53:10 UTC: %POLICY_ENGINE-6-POLICY_LOOKUP_EVENT: policy=POLICYNAME rule=RULENAME action=Permit direction=egress src.net.ip-address=IP src.net.port=38321 dst.net.ip-address=IP dst.net.port=5666 net.protocol=6 net.ethertype=800 net.service=\"protocol 6 port 5666\"";
 
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(toZonedDateTime(event.getDate(), UTC)).isEqualTo(ZonedDateTime.of(2016, 3, 6, 12, 53, 10, 0, UTC));
         assertThat(event.getFacility()).isEqualTo(16);
@@ -116,7 +113,7 @@ public class CiscoSyslogServerEventTest {
     public void testCisco7() throws Exception {
         final String message = "<166>%ASA-6-302015: Built inbound UDP connection 23631055 for inside:192.168.19.91/44764 (192.168.19.91/44764) to identity:192.168.249.33/161 (192.168.249.33/161)";
 
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(event.getDate())
                 .isInThePast()
@@ -131,7 +128,7 @@ public class CiscoSyslogServerEventTest {
     @Test
     public void testDefaultTimeZoneUtcIfNotConfigured() throws Exception {
         final String message = "<190>: 2016 Mar 06 09:22:34: %AUTHPRIV-6-SYSTEM_MSG: START: rsync pid=4311 from=::ffff:IP - xinetd[6219]";
-        final CiscoSyslogServerEvent event = buildEvent(message);
+        final CiscoSyslogServerEvent event = buildEvent(message, null);
 
         assertThat(toZonedDateTime(event.getDate(), UTC)).isEqualTo(ZonedDateTime.of(2016, 3, 6, 9, 22, 34, 0, UTC));
     }
@@ -139,7 +136,7 @@ public class CiscoSyslogServerEventTest {
     @Test
     public void testDefaultTimeZoneConfigured() throws Exception {
         final String message = "<190>: 2016 Mar 06 09:22:34: %AUTHPRIV-6-SYSTEM_MSG: START: rsync pid=4311 from=::ffff:IP - xinetd[6219]";
-        final CiscoSyslogServerEvent event = new CiscoSyslogServerEvent(message, INET_ADDR, MST);
+        final CiscoSyslogServerEvent event = buildEvent(message, MST);
 
         assertThat(toZonedDateTime(event.getDate(), MST_ZONE_ID)).isEqualTo(ZonedDateTime.of(2016, 3, 6, 9, 22, 34, 0, MST_ZONE_ID));
     }
@@ -148,7 +145,7 @@ public class CiscoSyslogServerEventTest {
     public void testDefaultTimeZoneIgnoredSinceZoneDetected() throws Exception {
         final String message = "<190>: 2016 Mar 06 09:22:34 CET: %AUTHPRIV-6-SYSTEM_MSG: START: rsync pid=4311 from=::ffff:IP - xinetd[6219]";
         DateTimeZone mst = DateTimeZone.forID("MST");
-        final CiscoSyslogServerEvent event = new CiscoSyslogServerEvent(message, INET_ADDR, mst);
+        final CiscoSyslogServerEvent event = buildEvent(message, mst);
 
         assertThat(toZonedDateTime(event.getDate(), CET)).isEqualTo(ZonedDateTime.of(2016, 3, 6, 9, 22, 34, 0, CET));
     }

--- a/src/test/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEventTest.java
+++ b/src/test/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEventTest.java
@@ -1,14 +1,20 @@
 package org.graylog2.syslog4j.server.impl.event;
 
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FortiGateSyslogEventTest {
+
+    public static final DateTimeZone MST_TIMEZONE = DateTimeZone.forID("MST");
+    public static final ZoneId MST = MST_TIMEZONE.toTimeZone().toZoneId();
+
     @Test
     public void testFortiGateMessage() {
         final String rawMessage = "<45>date=2017-03-06 time=12:53:10 devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=IP srcport=45748 srcintf=\"IF\" dstip=IP dstport=443 dstintf=\"IF\" sessionid=1122686199 status=close policyid=77 dstcountry=\"COUNTRY\" srccountry=\"COUNTRY\" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app=\"SSL_TLSv1.2\" appcat=\"Network.Service\" applist=\"ACLNAME\" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack=\"SSL\" hostname=\"HOSTNAME\" custom=\"white space\"";
@@ -31,4 +37,38 @@ public class FortiGateSyslogEventTest {
                 .containsEntry("custom", "white space");
     }
 
+    @Test
+    public void testDefaultTimezoneDetected() {
+        final String rawMessage = "<45>date=2017-03-06 time=12:53:10 tz=-0700 devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=IP srcport=45748 srcintf=\"IF\" dstip=IP dstport=443 dstintf=\"IF\" sessionid=1122686199 status=close policyid=77 dstcountry=\"COUNTRY\" srccountry=\"COUNTRY\" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app=\"SSL_TLSv1.2\" appcat=\"Network.Service\" applist=\"ACLNAME\" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack=\"SSL\" hostname=\"HOSTNAME\" custom=\"white space\"";
+        final FortiGateSyslogEvent event = new FortiGateSyslogEvent(rawMessage);
+
+        ZonedDateTime of = ZonedDateTime.of(2017, 3, 6, 12, 53, 10, 0, MST);
+
+        assertThat(ZonedDateTime.ofInstant(event.getDate().toInstant(), MST))
+                .isEqualTo(of);
+    }
+
+
+    @Test
+    public void testDefaultTimezoneConfigIgnored() {
+        final String rawMessage = "<45>date=2017-03-06 time=12:53:10 tz=+0000 devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=IP srcport=45748 srcintf=\"IF\" dstip=IP dstport=443 dstintf=\"IF\" sessionid=1122686199 status=close policyid=77 dstcountry=\"COUNTRY\" srccountry=\"COUNTRY\" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app=\"SSL_TLSv1.2\" appcat=\"Network.Service\" applist=\"ACLNAME\" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack=\"SSL\" hostname=\"HOSTNAME\" custom=\"white space\"";
+        final FortiGateSyslogEvent event = new FortiGateSyslogEvent(rawMessage, MST_TIMEZONE);
+
+        ZonedDateTime of = ZonedDateTime.of(2017, 3, 6, 12, 53, 10, 0, ZoneOffset.UTC);
+
+        assertThat(ZonedDateTime.ofInstant(event.getDate().toInstant(), ZoneOffset.UTC))
+                .isEqualTo(of);
+    }
+
+    @Test
+    public void testDefaultTimezoneConfigured() {
+        final String rawMessage = "<45>date=2017-03-06 time=12:53:10 devname=DEVICENAME devid=DEVICEID logid=0000000013 type=traffic subtype=forward level=notice vd=ALIAS srcip=IP srcport=45748 srcintf=\"IF\" dstip=IP dstport=443 dstintf=\"IF\" sessionid=1122686199 status=close policyid=77 dstcountry=\"COUNTRY\" srccountry=\"COUNTRY\" trandisp=dnat tranip=IP tranport=443 service=HTTPS proto=6 appid=41540 app=\"SSL_TLSv1.2\" appcat=\"Network.Service\" applist=\"ACLNAME\" appact=detected duration=1 sentbyte=2313 rcvdbyte=14883 sentpkt=19 rcvdpkt=19 utmaction=passthrough utmevent=app-ctrl attack=\"SSL\" hostname=\"HOSTNAME\" custom=\"white space\"";
+        final FortiGateSyslogEvent event = new FortiGateSyslogEvent(rawMessage, MST_TIMEZONE);
+
+        ZoneId mst = MST_TIMEZONE.toTimeZone().toZoneId();
+        ZonedDateTime of = ZonedDateTime.of(2017, 3, 6, 12, 53, 10, 0, mst);
+
+        assertThat(ZonedDateTime.ofInstant(event.getDate().toInstant(), mst))
+                .isEqualTo(of);
+    }
 }

--- a/src/test/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEventTest.java
+++ b/src/test/java/org/graylog2/syslog4j/server/impl/event/structured/StructuredSyslogServerEventTest.java
@@ -6,9 +6,6 @@ import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,11 +13,11 @@ import static org.junit.Assert.assertEquals;
 
 
 public class StructuredSyslogServerEventTest {
-    public static final DateTimeZone MST = DateTimeZone.forID("MST");
+    private static final DateTimeZone MST = DateTimeZone.forID("MST");
     private final InetAddress INET_ADDR = new InetSocketAddress(514).getAddress();
 
-    private StructuredSyslogServerEvent buildEvent(String message) {
-        return new StructuredSyslogServerEvent(message, INET_ADDR);
+    private StructuredSyslogServerEvent buildEvent(String message, DateTimeZone defaultZone) {
+        return new StructuredSyslogServerEvent(message, INET_ADDR, defaultZone);
     }
 
     @Test
@@ -28,7 +25,7 @@ public class StructuredSyslogServerEventTest {
         // Message from: https://tools.ietf.org/html/rfc5424#section-6.5
         final String message = "<165>1 2012-12-25T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry";
 
-        final StructuredSyslogServerEvent event = buildEvent(message);
+        final StructuredSyslogServerEvent event = buildEvent(message, null);
 
         Map<String, Map<String, String>> structuredData = new HashMap<String, Map<String, String>>() {
             {
@@ -60,7 +57,7 @@ public class StructuredSyslogServerEventTest {
         // Message from: https://github.com/Graylog2/graylog2-server/issues/845
         final String message = "<190>1 2015-01-06T20:56:33.287Z app-1 app - - [mdc@18060 ip=\"::ffff:132.213.51.30\" logger=\"{c.corp.Handler}\" session=\"4ot7\" user=\"user@example.com\" user-agent=\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/7.1.2 Safari/537.85.11\"] User page 13 requested";
 
-        final StructuredSyslogServerEvent event = buildEvent(message);
+        final StructuredSyslogServerEvent event = buildEvent(message, null);
 
         Map<String, Map<String, String>> structuredData = new HashMap<String, Map<String, String>>() {
             {
@@ -94,7 +91,7 @@ public class StructuredSyslogServerEventTest {
         // Message from: https://github.com/Graylog2/graylog2-server/issues/845
         final String message = "<128>1 2015-01-11T16:35:21.335797+01:00 s000000.example.com - - - - tralala";
 
-        final StructuredSyslogServerEvent event = buildEvent(message);
+        final StructuredSyslogServerEvent event = buildEvent(message, null);
 
         assertEquals(null, event.getApplicationName());
         assertEquals(new DateTime("2015-01-11T15:35:21.335797Z"), event.getDateTime());
@@ -114,7 +111,7 @@ public class StructuredSyslogServerEventTest {
         // Message from: https://tools.ietf.org/html/rfc5424#section-6.5
         final String message = "<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"]";
 
-        final StructuredSyslogServerEvent event = buildEvent(message);
+        final StructuredSyslogServerEvent event = buildEvent(message, null);
 
         Map<String, Map<String, String>> structuredData = new HashMap<String, Map<String, String>>() {
             {
@@ -153,7 +150,7 @@ public class StructuredSyslogServerEventTest {
         // Message from: https://tools.ietf.org/html/rfc5424#section-6.5
         final String message = "<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc 8710 - - %% It's time to make the do-nuts.";
 
-        final StructuredSyslogServerEvent event = buildEvent(message);
+        final StructuredSyslogServerEvent event = buildEvent(message, null);
 
         assertEquals("myproc", event.getApplicationName());
         assertEquals(new DateTime("2003-08-24T05:14:15.000003-07:00"), event.getDateTime());
@@ -174,7 +171,7 @@ public class StructuredSyslogServerEventTest {
         // Manually added ".000" to timestamp!
         final String message = "<45>1 2014-10-21T10:21:09.000+00:00 c4dc57ba1ebb syslog-ng 7120 - [meta sequenceId=\"1\"] syslog-ng starting up; version='3.5.3'";
 
-        final StructuredSyslogServerEvent event = buildEvent(message);
+        final StructuredSyslogServerEvent event = buildEvent(message, null);
 
         Map<String, Map<String, String>> structuredData = new HashMap<String, Map<String, String>>() {
             {
@@ -204,7 +201,7 @@ public class StructuredSyslogServerEventTest {
         // Message from: syslog-ng-core 3.5.3-1 package in Ubuntu 14.04 (default config)
         final String message = "<45>1 2014-10-21T10:21:09+00:00 c4dc57ba1ebb syslog-ng 7120 - [meta sequenceId=\"1\"] syslog-ng starting up; version='3.5.3'";
 
-        final StructuredSyslogServerEvent event = buildEvent(message);
+        final StructuredSyslogServerEvent event = buildEvent(message, null);
 
         Map<String, Map<String, String>> structuredData = new HashMap<String, Map<String, String>>() {
             {
@@ -235,17 +232,16 @@ public class StructuredSyslogServerEventTest {
         final String messageWithoutZone = "<45>1 2014-10-21T10:21:09 c4dc57ba1ebb syslog-ng 7120 - [meta sequenceId=\"1\"] syslog-ng starting up; version='3.5.3'";
         final String messageWithZone = "<45>1 2014-10-21T10:21:09-07:00 c4dc57ba1ebb syslog-ng 7120 - [meta sequenceId=\"1\"] syslog-ng starting up; version='3.5.3'";
 
-        assertEquals(new DateTime("2014-10-21T10:21:09.000"), buildEvent(messageWithoutZone).getDateTime());
-        assertEquals(new DateTime("2014-10-21T10:21:09.000-07:00"), buildEvent(messageWithZone).getDateTime());
+        assertEquals(new DateTime("2014-10-21T10:21:09.000"), buildEvent(messageWithoutZone, null).getDateTime());
+        assertEquals(new DateTime("2014-10-21T10:21:09.000-07:00"), buildEvent(messageWithZone, null).getDateTime());
     }
 
     @Test
     public void testDefaultTimeZoneSet() throws Exception {
-        // Message from: https://github.com/Graylog2/graylog2-server/issues/845
         final String messageWithoutZone = "<45>1 2014-10-21T10:21:09 c4dc57ba1ebb syslog-ng 7120 - [meta sequenceId=\"1\"] syslog-ng starting up; version='3.5.3'";
         final String messageWithZone = "<45>1 2014-10-21T10:21:09+01:00 c4dc57ba1ebb syslog-ng 7120 - [meta sequenceId=\"1\"] syslog-ng starting up; version='3.5.3'";
-        ZonedDateTime of = ZonedDateTime.of(2014, 10, 21, 10, 21, 9, 0, MST.toTimeZone().toZoneId());
-        assertEquals(new DateTime("2014-10-21T10:21:09.000-07:00", MST), new StructuredSyslogServerEvent(messageWithoutZone, INET_ADDR, MST).getDateTime());
-        assertEquals(new DateTime("2014-10-21T10:21:09.000+01:00"), new StructuredSyslogServerEvent(messageWithZone, INET_ADDR, MST).getDateTime());
+
+        assertEquals(new DateTime("2014-10-21T10:21:09.000-07:00", MST), buildEvent(messageWithoutZone,  MST).getDateTime());
+        assertEquals(new DateTime("2014-10-21T10:21:09.000+01:00"), buildEvent(messageWithZone, MST).getDateTime());
     }
 }


### PR DESCRIPTION
Part of https://github.com/Graylog2/graylog2-server/issues/3853

1. It is now possible to create syslog events with a default server timezone to be used during date parsing, if the message itself does not contain timezone information. 
2. Also improved FortiGate msg parsing to parse the tz field, which contains the timezone information. 


````
nc -w0 -u 0.0.0.0 514 <<< "<45>date=2023-02-21 time=10:30:10 tz=+0100 devname=DEVICENAME logid="0004000017" type="traffic" subtype="sniffer" level="notice" vd="root" eventtime=1557523134021045897 srcip=208.91.114.4 srcport=50463 srcintf="port1" srcintfrole="undefined" dstip=104.80.88.154 dstport=443 dstintf="port1" dstintfrole="undefined" sessionid=2193276 proto=6 action="accept" policyid=3 policytype="sniffer" service="HTTPS" dstcountry="United States" srccountry="Canada" trandisp="snat" transip=0.0.0.0 transport=0 duration=10 sentbyte=0 rcvdbyte=0 sentpkt=0 rcvdpkt=0 appcat="unscanned" utmaction="allow" countips=1 crscore=5 craction=32768 sentdelta=0 rcvddelta=0 utmref=65162-7772"
