### PR TITLE
Remove FortiGate unquoted KV_PATTERN for fileds

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
@@ -30,7 +30,6 @@ import static java.util.Objects.requireNonNull;
  */
 public class FortiGateSyslogEvent implements SyslogServerEventIF {
     private static final Pattern PRI_PATTERN = Pattern.compile("^<(\\d{1,3})>(.*)$");
-    private static final Pattern KV_PATTERN = Pattern.compile("(\\w+)=([^\\s\"]*)");
     private static final Pattern QUOTED_KV_PATTERN = Pattern.compile("(\\w+)=\"([^\"]*)\"");
 
     private String rawEvent;
@@ -85,10 +84,6 @@ public class FortiGateSyslogEvent implements SyslogServerEventIF {
 
     private void parseFields(String event) {
         final Map<String, String> fields = new HashMap<>();
-        final Matcher matcher = KV_PATTERN.matcher(event);
-        while (matcher.find()) {
-            fields.put(matcher.group(1), matcher.group(2));
-        }
         final Matcher quotedMatcher = QUOTED_KV_PATTERN.matcher(event);
         while (quotedMatcher.find()) {
             fields.put(quotedMatcher.group(1), quotedMatcher.group(2));


### PR DESCRIPTION
Unquoted fileds are not used in any FortiOS release post 5.x and parsing unqoted fileds creates erroneous fields when the log message has a URL filed like url="/test?field=value"