### PR TITLE
Fix FortiGate regex parsing fields

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
  * @see <a href="http://help.fortinet.com/fos50hlp/54/Content/FortiOS/fortigate-logging-reporting-54/logs.htm#Log_messages">FortiGate logging and reporting overview</a>
  */
 public class FortiGateSyslogEvent implements SyslogServerEventIF {
-    private static final Pattern PRI_PATTERN = Pattern.compile("^<(\\d{1,3})>(.*)$");
+    private static final Pattern PRI_PATTERN = Pattern.compile("^<(\\d{1,3})>(.*)");
     private static final Pattern KV_PATTERN = Pattern.compile("(\\w+)=(?:\"([^\"]*)\"|([^\\s\"]*))");
 
     private String rawEvent;
@@ -59,7 +59,7 @@ public class FortiGateSyslogEvent implements SyslogServerEventIF {
     private void parse(String event) {
         final Matcher matcher = PRI_PATTERN.matcher(event);
         if (!matcher.find()) {
-            throw new IllegalArgumentException("Invalid Fortigate syslog message");
+            throw new IllegalArgumentException("Invalid Fortigate syslog message: " + event);
         } else {
             final String priority = matcher.group(1);
             final String message = matcher.group(2);

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
@@ -30,8 +30,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class FortiGateSyslogEvent implements SyslogServerEventIF {
     private static final Pattern PRI_PATTERN = Pattern.compile("^<(\\d{1,3})>(.*)$");
-    private static final Pattern KV_PATTERN = Pattern.compile("(\\w+)=([^\\s\"]*)");
-    private static final Pattern QUOTED_KV_PATTERN = Pattern.compile("(\\w+)=\"([^\"]*)\"");
+    private static final Pattern KV_PATTERN = Pattern.compile("(\\w+)=(?:\"([^\"]*)\"|([^\\s\"]*))");
 
     private String rawEvent;
     private ZoneId defaultZoneId;
@@ -87,11 +86,7 @@ public class FortiGateSyslogEvent implements SyslogServerEventIF {
         final Map<String, String> fields = new HashMap<>();
         final Matcher matcher = KV_PATTERN.matcher(event);
         while (matcher.find()) {
-            fields.put(matcher.group(1), matcher.group(2));
-        }
-        final Matcher quotedMatcher = QUOTED_KV_PATTERN.matcher(event);
-        while (quotedMatcher.find()) {
-            fields.put(quotedMatcher.group(1), quotedMatcher.group(2));
+            fields.put(matcher.group(1), matcher.group(2) != null ? matcher.group(2) : matcher.group(3));
         }
         setFields(fields);
     }


### PR DESCRIPTION
Fix for Graylog2/graylog2-server#3854

Replaced existing KV_PATTERN and QUOTED_KV_PATTERN with a single regex reusing them with (?:|), it matches both quoted and unquoted fields and avoids creating erroneous fields when the log message has a URL filed like url="/test?field=value".