### PR TITLE
Fix syslog year rollover issues caused by time zone differences.

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/CiscoSyslogServerEvent.java
@@ -6,7 +6,6 @@ import java.net.InetAddress;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
@@ -147,7 +146,7 @@ public class CiscoSyslogServerEvent extends SyslogServerEvent {
 
             try {
                 if (isYearMissing) {
-                    String year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR));
+                    String year = deriveEventYearFromSystemTime();
                     String modifiedDate = year + " " + originalDate;
                     final ZonedDateTime dateTime = ZonedDateTime.parse(modifiedDate, formatter);
                     this.date = Date.from(dateTime.toInstant());

--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/SyslogServerEvent.java
@@ -11,12 +11,14 @@ import java.net.InetAddress;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.TimeZone;
 
 /**
  * SyslogServerEvent provides an implementation of the SyslogServerEventIF interface.
@@ -136,7 +138,7 @@ public class SyslogServerEvent implements SyslogServerEventIF {
     }
 
     private Date parseDateBasedOnFormat(String originalDate, int dateLength, String format) throws ParseException {
-        String year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR));
+        String year = deriveEventYearFromSystemTime();
         String modifiedDate = originalDate + " " + year;
         DateFormat dateFormat = new SimpleDateFormat(format, Locale.ENGLISH);
 
@@ -145,6 +147,14 @@ public class SyslogServerEvent implements SyslogServerEventIF {
         }
 
         return dateFormat.parse(modifiedDate);
+    }
+
+    protected String deriveEventYearFromSystemTime() {
+        ZoneId zoneId = Optional.ofNullable(sysLogServerTimeZone)
+                .map(tz -> tz.toTimeZone())
+                .map(TimeZone::toZoneId)
+                .orElse(ZoneId.systemDefault());
+        return Integer.toString(Year.now(zoneId).getValue());
     }
 
     private DateTime parse8601Date(String date) {


### PR DESCRIPTION
I've noticed an issue: [Graylog2/graylog2-server/issues/21472](https://github.com/Graylog2/graylog2-server/issues/21472)
RFC3164 syslog messages lack a year field.  The syslog4j library attempts to add this, but its logic relies on the JVM's default timezone.  This can lead to incorrect year appending during year rollovers if the JVM's timezone differs from the actual message's timezone.

For example, consider a message timestamped 2024-12-31T20:00:00-05:00 (EST), which is equivalent to 2025-01-01T01:00:00Z in UTC.  The correct year to append is 2024, but due to the year rollover, syslog4j might incorrectly append 2025. This results in the message being misinterpreted as originating from the future, 1 year later.

The solution is to prioritize using the syslogServerTimeZone to determine the year. If syslogServerTimeZone is unavailable, fall back to the JVM's default timezone.