### PR TITLE
Handle quoted fields in FortiGate parser

### DIFF
--- a/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
+++ b/src/main/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEvent.java
@@ -30,8 +30,12 @@ import static java.util.Objects.requireNonNull;
  */
 public class FortiGateSyslogEvent implements SyslogServerEventIF {
     private static final Pattern PRI_PATTERN = Pattern.compile("^<(\\d{1,3})>(.*)$");
-    private static final Pattern KV_PATTERN = Pattern.compile("(\\w+)=([^\\s\"]*)");
-    private static final Pattern QUOTED_KV_PATTERN = Pattern.compile("(\\w+)=\"([^\"]*)\"");
+    /*
+     * Matches `key="quoted"` or `key=unquoted`.
+     * Group 2 captures a quoted value (with `\<char>` recognized as an escape).
+     * Group 3 captures an unquoted value.
+     */
+    private static final Pattern KV_PATTERN = Pattern.compile("(\\w+)=(?:\"((?:[^\"\\\\]|\\\\.)*)\"|([^\\s\"]*))");
 
     private String rawEvent;
     private ZoneId defaultZoneId;
@@ -87,11 +91,8 @@ public class FortiGateSyslogEvent implements SyslogServerEventIF {
         final Map<String, String> fields = new HashMap<>();
         final Matcher matcher = KV_PATTERN.matcher(event);
         while (matcher.find()) {
-            fields.put(matcher.group(1), matcher.group(2));
-        }
-        final Matcher quotedMatcher = QUOTED_KV_PATTERN.matcher(event);
-        while (quotedMatcher.find()) {
-            fields.put(quotedMatcher.group(1), quotedMatcher.group(2));
+            final String value = matcher.group(2) != null ? matcher.group(2) : matcher.group(3);
+            fields.put(matcher.group(1), value);
         }
         setFields(fields);
     }

--- a/src/test/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEventTest.java
+++ b/src/test/java/org/graylog2/syslog4j/server/impl/event/FortiGateSyslogEventTest.java
@@ -71,4 +71,48 @@ public class FortiGateSyslogEventTest {
         assertThat(ZonedDateTime.ofInstant(event.getDate().toInstant(), mst))
                 .isEqualTo(of);
     }
+
+    @Test
+    public void quotedValueWithEqualsDoesNotProducePhantomFields() {
+        final String rawMessage = "<99>date=2025-06-12 time=13:17:12 devname=\"FW1\" tz=\"+00:00\" url=\"/p/AF1QipMv0l3HYdRc5_YuViCfIIbOZz6ipH4Jb6QV6ngM=w92-h92-n-k-no\"";
+        final FortiGateSyslogEvent event = new FortiGateSyslogEvent(rawMessage);
+
+        assertThat(event.getFields())
+                .containsEntry("url", "/p/AF1QipMv0l3HYdRc5_YuViCfIIbOZz6ipH4Jb6QV6ngM=w92-h92-n-k-no")
+                .doesNotContainKey("AF1QipMv0l3HYdRc5_YuViCfIIbOZz6ipH4Jb6QV6ngM")
+                .doesNotContainValue("w92-h92-n-k-no");
+    }
+
+    @Test
+    public void quotedValueDoesNotOverwriteSiblingFields() {
+        final String rawMessage = "<99>date=2025-06-12 time=13:17:12 devname=\"FW1\" tz=\"+00:00\" srcip=10.31.110.152 dstip=192.178.50.65 url=\"/whatever.php?srcip=127.0.0.1&dstip=127.0.0.1\"";
+        final FortiGateSyslogEvent event = new FortiGateSyslogEvent(rawMessage);
+
+        assertThat(event.getFields())
+                .containsEntry("srcip", "10.31.110.152")
+                .containsEntry("dstip", "192.178.50.65")
+                .containsEntry("url", "/whatever.php?srcip=127.0.0.1&dstip=127.0.0.1");
+    }
+
+    @Test
+    public void backslashEscapedQuoteInsideQuotedValueIsConsumedAtomically() {
+        final String rawMessage = "<99>date=2025-06-12 time=13:17:12 srcip=10.0.0.1 url=\"/test?\\\"srcip=127.0.0.1\"";
+        final FortiGateSyslogEvent event = new FortiGateSyslogEvent(rawMessage);
+
+        assertThat(event.getFields())
+                .containsEntry("srcip", "10.0.0.1")
+                .containsEntry("url", "/test?\\\"srcip=127.0.0.1");
+    }
+
+    @Test
+    public void quotedValueDoesNotCorruptParseTimeFields() {
+        final String rawMessage = "<99>date=2025-06-12 time=13:17:12 devname=\"FW1\" tz=\"+00:00\" url=\"/whatever.php?time=1\"";
+        final FortiGateSyslogEvent event = new FortiGateSyslogEvent(rawMessage);
+
+        assertThat(event.getFields())
+                .containsEntry("time", "13:17:12")
+                .containsEntry("url", "/whatever.php?time=1");
+        assertThat(ZonedDateTime.ofInstant(event.getDate().toInstant(), ZoneOffset.UTC))
+                .isEqualTo(ZonedDateTime.of(2025, 6, 12, 13, 17, 12, 0, ZoneOffset.UTC));
+    }
 }


### PR DESCRIPTION
In the FortiGate syslog parser, a `key=value` inside a quoted field (e.g. `url="..."`) was being extracted as a top-level field, which can corrupt the message.

The parser now uses a single combined regex that consumes the entire quoted value in one match (also supports escaped quotes).